### PR TITLE
Recursive file gathering for pdf to image conversion

### DIFF
--- a/main/configs/pdf_img_pipeline_config.json
+++ b/main/configs/pdf_img_pipeline_config.json
@@ -2,5 +2,8 @@
     "pdf_dir": "",
     "output_dir": "",
     "scale": 4,
-    "absolute_path": false
+    "absolute_path": false,
+    "max_depth": 10,
+    "min_file_size_kb": 0,
+    "max_file_size_kb": 20480
 }

--- a/main/configs/pdf_img_pipeline_config_local.json
+++ b/main/configs/pdf_img_pipeline_config_local.json
@@ -2,5 +2,8 @@
     "pdf_dir": "C:\\Users\\User\\src\\marine-process-docs",
     "output_dir": "marine-process-imgs",
     "scale": 4,
-    "absolute_path": true
+    "absolute_path": true,
+    "max_depth": 10,
+    "min_file_size_kb": 0,
+    "max_file_size_kb": 20480
 }

--- a/main/configs/pdf_img_recursion_test.json
+++ b/main/configs/pdf_img_recursion_test.json
@@ -1,0 +1,9 @@
+{
+    "pdf_dir": "C:\\Users\\User\\src\\mp-docs-recursion",
+    "output_dir": "marine-process-imgs",
+    "scale": 4,
+    "absolute_path": false,
+    "max_depth": 10,
+    "min_file_size_kb": 0,
+    "max_file_size_kb": 20480
+}

--- a/main/pdf_img_pipeline.py
+++ b/main/pdf_img_pipeline.py
@@ -90,10 +90,14 @@ def save_document(file_name: str, file_path: str) -> None:
 
 
 def get_pdf_paths(
-    dir: str, output_dir: str, absolute_path: bool = False
+    dir: str,
+    absolute_path: bool = False,
+    max_depth: int = 10,
+    min_file_size: int = 1,
+    max_file_size: int = float("inf"),
 ) -> list[str]:
     """
-    Finds all PDFs in a directory, saves to DB, returns full paths.
+    Recursively finds all PDFs in a directory, saves to DB, returns full paths.
 
     Scans directory for PDFs, verifies each file, stores in database.
     Returns list of full paths to found PDF files.
@@ -103,6 +107,9 @@ def get_pdf_paths(
         output_dir: Directory for processed files/output.
         absolute_path: If True, treats 'dir' as absolute path. If False,
             resolves relative to current working directory.
+        max_depth: Maximum depth to search for PDFs (default: 10).
+        min_file_size: Minimum file size in bytes to consider (default: 1).
+        max_file_size: Maximum file size in bytes to consider (default: inf).
 
     Returns:
         List of full paths to found PDF files.
@@ -115,27 +122,25 @@ def get_pdf_paths(
         - Logs warnings for non-file entries (e.g., directories)
         - Auto-saves documents via save_document()
     """
-    # Setup and verify the PDF data directory
     pdf_data_dir = resolve_dir_path(dir, absolute_path)
-
-    pdf_paths = [f for f in os.listdir(pdf_data_dir) if f.endswith(".pdf")]
-    assert len(pdf_paths) > 0, f"No PDF files found in {pdf_data_dir}"
-
-    # Collect the full paths of the PDF files
     full_pdf_paths = []
 
-    for path in pdf_paths:
-        new_path = os.path.join(pdf_data_dir, path)
+    for dirpath, _, filenames in os.walk(pdf_data_dir):
+        for filename in filenames:
+            if filename.lower().endswith(".pdf"):
+                full_path = os.path.join(dirpath, filename)
+                if os.path.isfile(full_path):
+                    full_pdf_paths.append(full_path)
+                    # Add the document to the database
+                    save_document(filename, full_path)
+                else:
+                    logging.warning(f"{full_path} is not a file")
 
-        # Check if the path is a file
-        if os.path.isfile(new_path):
-            full_pdf_paths.append(new_path)
-        else:
-            logging.warning(f"{new_path} is not a file")
-            continue
-
-        # Add the document to the database, path acts as the file's name
-        save_document(path, new_path)
+    is_paths_empty = len(full_pdf_paths) == 0
+    if is_paths_empty:
+        raise AssertionError(
+            f"No PDF files found in {pdf_data_dir} or its subdirectories"
+        )
 
     return full_pdf_paths
 
@@ -171,9 +176,17 @@ def check_already_converted(pdf_path: str) -> bool:
         return False
 
 
-def save_img(parent_doc: Document, page_num: int, img_path: str):
+def save_img_to_db(parent_doc: Document, page_num: int, img_path: str):
     """
     Save the image to the output directory and add the page to the database.
+
+    Args:
+        parent_doc: Document object for the parent PDF
+        page_num: Page number of the image
+        img_path: Path to the image file
+
+    Raises:
+        IntegrityError: If database constraints are violated during
     """
     try:
         Page.create(
@@ -184,6 +197,41 @@ def save_img(parent_doc: Document, page_num: int, img_path: str):
         logging.error(f"Error with page {page_num} of {parent_doc.name}: {e}")
 
 
+def convert_pdf(
+    path: str,
+    parent_doc: Document,
+    base_name: str,
+    file_name: str,
+    output_dir: str,
+    scale: int = 4,
+):
+    """
+    Convert a single PDF to images while tracking state in database.
+
+    Args:
+        pdf: Pdfium PDF object to convert
+        parent_doc: Document object for the parent PDF
+        base_name: Base name of the PDF file
+        file_name: Full name of the PDF file with the extension
+        output_dir: Directory to save converted images
+        scale: Scaling factor for image conversion (default: 4)
+    """
+    pdf = pdfium.PdfDocument(path)
+
+    for i in range(len(pdf)):
+        page = pdf[i]
+        img = create_img_and_pad_divisible_by_32(page, scale=scale)
+        new_name = f"{base_name}_{i}.png"
+        new_path = os.path.join(output_dir, new_name)
+
+        # Save img to output and data to db
+        img.save(new_path)
+        logging.info(f"Page {i} of {file_name} saved as image.")
+        save_img_to_db(parent_doc, i, new_path)
+
+    pdf.close()
+
+
 def convert_pdfs(pdf_paths: list[str], output_dir: str, scale: int = 4):
     """
     Convert PDFs to images while tracking state in database.
@@ -192,6 +240,10 @@ def convert_pdfs(pdf_paths: list[str], output_dir: str, scale: int = 4):
         pdf_paths: List of PDF file paths to convert
         output_dir: Directory to save converted images
         scale: Scaling factor for image conversion (default: 4)
+
+    Raises:
+        Document.DoesNotExist: If a document is not found in the
+        database when trying to convert it
     """
     for path in pdf_paths:
         if check_already_converted(path):
@@ -203,21 +255,9 @@ def convert_pdfs(pdf_paths: list[str], output_dir: str, scale: int = 4):
 
         try:
             parent_doc = Document.get(Document.name == file_name)
-
-            pdf = pdfium.PdfDocument(path)
-
-            for i in range(len(pdf)):
-                page = pdf[i]
-                img = create_img_and_pad_divisible_by_32(page, scale=scale)
-                new_name = f"{base_name}_{i}.png"
-                new_path = os.path.join(output_dir, new_name)
-
-                # Save img to output and data to db
-                img.save(new_path)
-                logging.info(f"Page {i} of {file_name} saved as image.")
-                save_img(parent_doc, i, new_path)
-
-            pdf.close()
+            convert_pdf(
+                path, parent_doc, base_name, file_name, output_dir, scale=scale
+            )
         except Document.DoesNotExist:
             logging.error(f"Document {file_name} not found in database.")
             raise ValueError(f"Document {file_name} not found in database.")
@@ -235,9 +275,19 @@ def main_pipeline(config=None):
     output_dir = config.get("output_dir")
     scale = config.get("scale")
     absolute_path = config.get("absolute_path")
+    max_depth = config.get("max_depth")
+    min_file_size = config.get("min_file_size_kb") * 1024
+    max_file_size = config.get("max_file_size_kb") * 1024
 
     os.makedirs(output_dir, exist_ok=True)
-    pdf_paths = get_pdf_paths(pdf_dir, output_dir, absolute_path=absolute_path)
+    pdf_paths = get_pdf_paths(
+        pdf_dir,
+        output_dir,
+        absolute_path=absolute_path,
+        max_depth=max_depth,
+        min_file_size=min_file_size,
+        max_file_size=max_file_size,
+    )
     convert_pdfs(pdf_paths, output_dir, scale=scale)
 
     logging.info("PDFs converted to images.")


### PR DESCRIPTION
This pull request includes multiple changes to the `pdf_img_pipeline` to enhance its functionality by adding new configuration options and improving the code structure. The most important changes include adding new configuration parameters to control the depth and file size of the PDFs to be processed, refactoring the `convert_pdfs` function to handle individual PDF conversion, and renaming functions for better clarity.

Enhancements to configuration:

* [`main/configs/pdf_img_pipeline_config.json`](diffhunk://#diff-34a07b574b36662142089c74b8439407b63f4c2a76d411bbe4fbff19fe40514fL5-R8): Added `max_depth`, `min_file_size_kb`, and `max_file_size_kb` parameters to control the depth of directory traversal and the size range of PDF files to process.
* [`main/configs/pdf_img_pipeline_config_local.json`](diffhunk://#diff-eeefe17645757fc02344a36808a5c511a78ebc56c98b0c515e173dedc94f33b7L5-R8): Added `max_depth`, `min_file_size_kb`, and `max_file_size_kb` parameters for local configuration.
* [`main/configs/pdf_img_recursion_test.json`](diffhunk://#diff-c697ad4652415186f5f06199816e69bf26a1a099eb4ef22126ed1b1de622a17aR1-R9): Created a new configuration file for recursion testing with the new parameters.

Code refactoring and improvements:

* [`main/pdf_img_pipeline.py`](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL93-R111): Updated `get_pdf_paths` function to include `max_depth`, `min_file_size`, and `max_file_size` parameters, and refactored the function to handle these new parameters. [[1]](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL93-R111) [[2]](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL118-R159)
* [`main/pdf_img_pipeline.py`](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL174-R205): Split the `convert_pdfs` function into `convert_pdf` for individual PDF conversion and `convert_pdfs` for handling multiple PDFs, and renamed `save_img` to `save_img_to_db` for better clarity. [[1]](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL174-R205) [[2]](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL187-L206) [[3]](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eL218-R276)
* [`main/pdf_img_pipeline.py`](diffhunk://#diff-8accd9a2f59800fd2abbeaa491e33b3c197c55d16f88f6b9f813977d4f4e6d4eR294-R305): Updated `main_pipeline` function to pass the new configuration parameters to `get_pdf_paths`.